### PR TITLE
Petr's WGLC comments: removed text discussing 'DNS protocol processin…

### DIFF
--- a/draft-ietf-dnsop-structured-dns-error.md
+++ b/draft-ietf-dnsop-structured-dns-error.md
@@ -580,11 +580,7 @@ The application that triggered the DNS request may have a client security policy
 ## Authentication and Confidentiality
 
 Security considerations in {{Section 6 of !RFC8914}} apply to this
-document, except the guard against using EDE content to alter DNS protocol
-processing. The guard is relaxed in the current specification as it mandates
-DNS encryption and recommends the use of an authenticated connection to the DNS
-server, while {{!RFC8914}} assumes that EDE information is unauthenticated
-and sent over clear text.
+document.
 
 To minimize impact of active on-path attacks on the DNS channel, the
 client validates the response as described in {{client-processing}}.

--- a/draft-ietf-dnsop-structured-dns-error.md
+++ b/draft-ietf-dnsop-structured-dns-error.md
@@ -580,7 +580,7 @@ The application that triggered the DNS request may have a client security policy
 ## Authentication and Confidentiality
 
 Security considerations in {{Section 6 of !RFC8914}} apply to this
-document.
+document. {{!RFC8914}} cautions against relying on EDE information because it may be unauthenticated and transmitted in cleartext. This specification assumes the use of encrypted DNS transports and recommends authenticated connections to the DNS server. Under these conditions, EDE information is integrity-protected, reducing the risks associated with relying on structured EDE content.
 
 To minimize impact of active on-path attacks on the DNS channel, the
 client validates the response as described in {{client-processing}}.


### PR DESCRIPTION
…g' and 'guard against' -- which does not appear in RFC8914.

@tireddy2 , be sure to review this change -- I have less confidence on this edit and there may well be something the original text was trying to convey and I blew it all away.